### PR TITLE
fix(gfm): писать recovery-настройки после pg_rewind и описать нужные гранты

### DIFF
--- a/plugins/gfm/gfm_rebuild.sh
+++ b/plugins/gfm/gfm_rebuild.sh
@@ -100,7 +100,9 @@ if [ -f "$PG_DATA/global/pg_control" ]; then
         log_msg "SUCCESS: pg_rewind completed."
         REWIND_OK=1
     else
-        log_msg "NOTICE: pg_rewind failed (this is normal if timelines diverged too much)."
+        log_msg "NOTICE: pg_rewind failed, falling back to full pg_basebackup."
+        log_msg "HINT: if it says 'permission denied for function pg_read_binary_file',"
+        log_msg "HINT: user $USER is missing the pg_rewind GRANTs (see plugin readme)."
     fi
 fi
 
@@ -131,6 +133,28 @@ fi
 # В современных версиях PG (12+) standby.signal создается автоматически ключом -R в pg_basebackup,
 # но мы подстрахуемся для надежности.
 sudo -u postgres touch "$PG_DATA/standby.signal"
+
+# После pg_rewind каталог данных сохраняет postgresql.auto.conf источника,
+# а вместе с ним primary_conninfo и primary_slot_name прежнего мастера.
+# На ветке pg_basebackup эти параметры переписывает ключ -R, здесь их нужно
+# проставить самим, иначе нода уйдет стримить не туда (например, сама на себя).
+if [ $REWIND_OK -eq 1 ]; then
+    log_msg "Writing recovery configuration for master $MASTER_HOST..."
+    AUTO_CONF="$PG_DATA/postgresql.auto.conf"
+    sudo -u postgres touch "$AUTO_CONF"
+    sudo -u postgres sed -i '/^primary_conninfo/d; /^primary_slot_name/d' "$AUTO_CONF"
+    printf "primary_conninfo = 'host=%s port=%s user=%s application_name=%s'\nprimary_slot_name = '%s'\n" \
+        "$MASTER_HOST" "$PG_PORT" "$USER" "$MY_NAME" "$SLOT_NAME" \
+        | sudo -u postgres tee -a "$AUTO_CONF" > /dev/null
+
+    # Слот на мастере заводит только pg_basebackup --create-slot, на этой ветке его нет.
+    log_msg "Ensuring replication slot $SLOT_NAME on $MASTER_HOST..."
+    sudo -u postgres "$PG_BIN/psql" -h "$MASTER_HOST" -p "$PG_PORT" -U "$USER" -d postgres -tAc \
+        "SELECT pg_create_physical_replication_slot('$SLOT_NAME') WHERE NOT EXISTS \
+         (SELECT 1 FROM pg_replication_slots WHERE slot_name = '$SLOT_NAME');" \
+        >> "$LOG_FILE" 2>&1 || log_msg "WARNING: could not create slot $SLOT_NAME (may already exist)."
+fi
+
 chown -R postgres:postgres "$PG_DATA"
 
 # Перед запуском проверяем, что конфиг в /etc смотрит на правильный порт

--- a/plugins/gfm/readme.md
+++ b/plugins/gfm/readme.md
@@ -165,6 +165,17 @@ Since GFM manages the failover orchestration, you must ensure PostgreSQL is manu
    ```sql
    CREATE USER repuser WITH REPLICATION PASSWORD 'your_secure_password';
    ```
+   `REPLICATION` alone is enough for `pg_basebackup`, but `pg_rewind` connects as
+   the same user and additionally needs to read files on the source node. Without
+   these grants every `pg_rewind` fails with
+   `permission denied for function pg_read_binary_file` and `gfm_rebuild.sh`
+   silently falls back to a full `pg_basebackup`:
+   ```sql
+   GRANT EXECUTE ON FUNCTION pg_catalog.pg_ls_dir(text, boolean, boolean) TO repuser;
+   GRANT EXECUTE ON FUNCTION pg_catalog.pg_stat_file(text, boolean) TO repuser;
+   GRANT EXECUTE ON FUNCTION pg_catalog.pg_read_binary_file(text) TO repuser;
+   GRANT EXECUTE ON FUNCTION pg_catalog.pg_read_binary_file(text, bigint, bigint, boolean) TO repuser;
+   ```
 2. **Configure Authentication (`.pgpass`):**
    The `gfm_rebuild.sh` script requires a `.pgpass` file in the postgres home directory (chmod `0600`):
    ```text


### PR DESCRIPTION
# fix(gfm): писать recovery-настройки после pg_rewind и описать нужные гранты

Патч к #4. Пин: `f2820af610f1962e8b2d61b6cad4f493b60f8eb6`.

Коротко, что чинится:

1. `pg_rewind` подключается как `repuser`, а readme плагина заводит эту роль только с `REPLICATION`. Прав на чтение файлов на источнике нет, поэтому `pg_rewind` падал всегда, а скрипт записывал это как «this is normal» и уходил в полный `pg_basebackup`.
2. После выдачи грантов `pg_rewind` начинает работать, и выясняется, что на этой ветке никто не пишет `primary_conninfo` и `primary_slot_name`. Их проставляет ключ `-R`, который есть только у `pg_basebackup`. Каталог данных приезжает с источника вместе с его `postgresql.auto.conf`, и после failover нода начинает стримить сама с себя по чужому слоту.

## Что в патче

В `gfm_rebuild.sh` после успешного `pg_rewind`:

- вычищаем из `postgresql.auto.conf` унаследованные `primary_conninfo` и `primary_slot_name` и пишем свои, под нового мастера;
- заводим слот на мастере, если его ещё нет (`--create-slot` есть только у `pg_basebackup`);
- сообщение при неудаче `pg_rewind` больше не выглядит как «всё в порядке» и подсказывает про гранты.

В `plugins/gfm/readme.md` добавлены четыре гранта из документации pg_rewind в Post-Installation Checklist, рядом с созданием `repuser`.

Ветка `pg_basebackup` не тронута.

## Проверка

Стенд на двух PostgreSQL 17 (подробности в issue). До патча после `pg_rewind: Done!` в каталоге перестроенной ноды, слушающей 5441:

```
primary_conninfo = '... host=127.0.0.1 port=5441 ...'
primary_slot_name = 'replica_slot_b'
```

Порт свой собственный, слот чужой. В логе `started streaming WAL from primary at 0/3000000 on timeline 1`, хотя новый мастер уже на timeline 2.

После патча:

```
primary_conninfo = 'host=127.0.0.1 port=5442 user=repuser application_name=nodeA'
primary_slot_name = 'replica_slot_a'

pg_stat_replication на новом мастере:   nodeA | streaming | async
pg_stat_wal_receiver на реплике:        streaming | порт источника=5442 | слот=replica_slot_a
```

Запись, сделанная на новом мастере, доезжает до перестроенной ноды, `received_tli` становится 2.

Проверяли и на своём k3d-кластере в составе оператора.

Если что-то стоит сделать иначе, скажите, поправим.
