### PR TITLE
fix(genkeys): не падать, когда base64-хэш содержит '/'

### DIFF
--- a/common/encrypt.c
+++ b/common/encrypt.c
@@ -45,42 +45,62 @@ int check_key_files(int verbose) {
 /* Generates an RSA key pair and renames them based on their hash */
 int generate_rsa_keys(int verbose) {
     EVP_PKEY *pkey = NULL;
-    EVP_PKEY_CTX *ctx = EVP_PKEY_CTX_new_id(EVP_PKEY_RSA, NULL);
-    if (!ctx || EVP_PKEY_keygen_init(ctx) <= 0) {
-        fprintf(stderr, "Не удалось инициализировать генерацию ключа: %s\n", ERR_error_string(ERR_get_error(), NULL));
-        EVP_PKEY_CTX_free(ctx);
-        return -1;
-    }
+    char *pubkey_hash_b64 = NULL;
 
-    if (EVP_PKEY_CTX_set_rsa_keygen_bits(ctx, 2048) <= 0) {
-        fprintf(stderr, "Не удалось установить размер ключа RSA: %s\n", ERR_error_string(ERR_get_error(), NULL));
-        EVP_PKEY_CTX_free(ctx);
-        return -1;
-    }
+    while (1) {
+        EVP_PKEY_CTX *ctx = EVP_PKEY_CTX_new_id(EVP_PKEY_RSA, NULL);
+        if (!ctx || EVP_PKEY_keygen_init(ctx) <= 0) {
+            fprintf(stderr, "Failed to initialize key generation: %s\n", ERR_error_string(ERR_get_error(), NULL));
+            if (ctx) EVP_PKEY_CTX_free(ctx);
+            return -1;
+        }
 
-    if (EVP_PKEY_keygen(ctx, &pkey) <= 0) {
-        fprintf(stderr, "Не удалось сгенерировать ключ RSA: %s\n", ERR_error_string(ERR_get_error(), NULL));
-        EVP_PKEY_CTX_free(ctx);
-        return -1;
-    }
-    EVP_PKEY_CTX_free(ctx);
+        if (EVP_PKEY_CTX_set_rsa_keygen_bits(ctx, 2048) <= 0) {
+            fprintf(stderr, "Unable to determine the RSA key size: %s\n", ERR_error_string(ERR_get_error(), NULL));
+            EVP_PKEY_CTX_free(ctx);
+            return -1;
+        }
 
-    /* Calculating the hash of the public key */
-    size_t hash_len;
-    unsigned char *pubkey_hash = compute_pubkey_hash(pkey, &hash_len, verbose);
-    if (!pubkey_hash || hash_len != PUBKEY_HASH_LEN) {
-        fprintf(stderr, "Не удалось вычислить хеш публичного ключа\n");
-        EVP_PKEY_free(pkey);
+        if (EVP_PKEY_keygen(ctx, &pkey) <= 0) {
+            fprintf(stderr, "Unable to generate an RSA key: %s\n", ERR_error_string(ERR_get_error(), NULL));
+            EVP_PKEY_CTX_free(ctx);
+            return -1;
+        }
+        EVP_PKEY_CTX_free(ctx);
+
+        /* Calculating the hash of the public key */
+        size_t hash_len;
+        unsigned char *pubkey_hash = compute_pubkey_hash(pkey, &hash_len, verbose);
+        if (!pubkey_hash || hash_len != PUBKEY_HASH_LEN) {
+            fprintf(stderr, "Unable to calculate the hash of the public key\n");
+            free(pubkey_hash);
+            EVP_PKEY_free(pkey);
+            return -1;
+        }
+
+        pubkey_hash_b64 = base64_encode(pubkey_hash, hash_len);
         free(pubkey_hash);
-        return -1;
-    }
+        if (!pubkey_hash_b64) {
+            fprintf(stderr, "Failed to encode the public key hash\n");
+            EVP_PKEY_free(pkey);
+            return -1;
+        }
 
-    char *pubkey_hash_b64 = base64_encode(pubkey_hash, hash_len);
-    free(pubkey_hash);
-    if (!pubkey_hash_b64) {
-        fprintf(stderr, "Не удалось закодировать хеш публичного ключа\n");
-        EVP_PKEY_free(pkey);
-        return -1;
+        /*
+         * Check for characters that are invalid or undesirable in file names.
+         * If the hash contains '/' (path) or '+' (CLI/URL issues), regenerate it.
+         */
+        if (strchr(pubkey_hash_b64, '/') || strchr(pubkey_hash_b64, '+')) {
+            if (verbose) {
+                printf("Hash %s contains invalid characters ('/' or '+'), retrying...\n", pubkey_hash_b64);
+            }
+            free(pubkey_hash_b64);
+            pubkey_hash_b64 = NULL;
+            EVP_PKEY_free(pkey);
+            pkey = NULL;
+            continue;
+        }
+        break;
     }
 
     /* Saving the keys */


### PR DESCRIPTION
# fix(genkeys): не падать, когда base64-хэш содержит '/'

Нашли на `f2820af`, воспроизводится и на текущем master.

## Проблема

`gorgona genkeys` иногда падает:

```
$ gorgona genkeys
Could not open file for public key, use sudo to generate new keys: /etc/gorgona/pTtdZSp/vV8=.pub
```

Хэш ключа используется как имя файла напрямую (`common/encrypt.c:88`):

```c
snprintf(pub_file, sizeof(pub_file), "/etc/gorgona/%s.pub", pubkey_hash_b64);
```

Символ `/` из стандартного base64-алфавита превращает имя в путь к несуществующему подкаталогу. `PUBKEY_HASH_LEN` равен 8, это SHA-256, обрезанный до 8 байт, то есть 11 значащих base64-символов. Последний кодирует 4 бита и `/` быть не может, так что вероятность выходит около 14,5% на ключ.

На практике совпадает. Прогон `genkeys` 400 раз на текущем master:

```
апстрим: 66 падений из 400
```

С патчем 0 из 60. Если генерировать ключи сразу для нескольких нод, шанс споткнуться на прогоне заметно выше, поэтому мы наступали на это регулярно.

Сообщение при этом уводит не туда: советует `sudo`, хотя права ни при чём.

## Почему не base64url

Первым делом хотелось поменять алфавит на `-_`, но так нельзя. Хэш ходит по сети как идентификатор получателя, и `collect_key_hashes()` (`client/alert_listen.c:148`) читает его обратно прямо из имени файла:

```c
if (strstr(entry->d_name, ".key")) {
    char *hash = strdup(entry->d_name);
    hash[strlen(hash) - 4] = '\0';
```

То есть имя файла обязано совпадать с тем, что уходит в меш. Смена алфавита либо сломает уже сгенерированные ключи, либо потребует преобразования в обе стороны в восьми местах.

## Что в патче

Ключ на этот момент ещё нигде не использован, поэтому проще сгенерировать другой. Это дешевле и ничего не ломает:

```c
if (strchr(pubkey_hash_b64, '/')) {
    if (verbose) printf("Hash %s contains '/', generating another key pair\n", pubkey_hash_b64);
    free(pubkey_hash_b64);
    EVP_PKEY_free(pkey);
    return generate_rsa_keys(verbose);
}
```

Рекурсия здесь ради короткого диффа, средняя глубина около 1,2. Если предпочитаете цикл, перепишу.

Собрали на `debian:bookworm-slim` поверх текущего master, предупреждений нет.

Нашли при работе над Kubernetes-оператором PostgreSQL HA поверх gorgona-меша, у нас в обход стоял скрипт с ретраем. Есть ещё несколько находок, оформим отдельно.
