### PR TITLE
fix(server): дать возможность задать абсолютный путь к gorgonad.log

### DIFF
--- a/server/gorgona_utils.c
+++ b/server/gorgona_utils.c
@@ -646,13 +646,27 @@ void send_current_alerts(int sub_index, int mode, const char *pubkey_hash_b64_fi
     }
 }
 
+/*
+ * Log destination. Defaults to the historical relative path, so nothing changes
+ * for existing installs; set gorgonad_LOG_FILE to pin it to an absolute path
+ * (mirrors gorgona_LOG_FILE on the client side).
+ */
+const char *gorgonad_log_path(void) {
+    const char *path = getenv("gorgonad_LOG_FILE");
+    return (path && *path) ? path : "gorgonad.log";
+}
+
 void rotate_log() {
     time_t now = time(NULL);
     if (now - last_rotation_check < 5) return;
     last_rotation_check = now;
 
+    const char *path = gorgonad_log_path();
+    char rotated[512];
+    snprintf(rotated, sizeof(rotated), "%s.1", path);
+
     struct stat st;
-    if (stat("gorgonad.log", &st) == 0 && (size_t)st.st_size > max_log_size) {
+    if (stat(path, &st) == 0 && (size_t)st.st_size > max_log_size) {
         if (log_file) {
             char time_str[32];
             get_utc_time_str(time_str, sizeof(time_str));
@@ -660,8 +674,8 @@ void rotate_log() {
             fflush(log_file);
             fclose(log_file);
         }
-        rename("gorgonad.log", "gorgonad.log.1");
-        log_file = fopen("gorgonad.log", "a");
+        rename(path, rotated);
+        log_file = fopen(path, "a");
         if (!log_file) {
             perror("Failed to open new log file");
         }

--- a/server/gorgona_utils.h
+++ b/server/gorgona_utils.h
@@ -91,6 +91,7 @@ typedef struct {
 
 /* Global variables */
 extern FILE *log_file;
+const char *gorgonad_log_path(void);
 extern Recipient *recipients;
 extern int recipient_count;
 extern int recipient_capacity;

--- a/server/gorgonad.c
+++ b/server/gorgonad.c
@@ -187,9 +187,9 @@ int main(int argc, char *argv[]) {
      * After opening the file, all subsequent logs must use log_event().
      */
     if (log_file == NULL) {
-        log_file = fopen("gorgonad.log", "a");
+        log_file = fopen(gorgonad_log_path(), "a");
         if (!log_file) {
-            perror("Failed to open gorgonad.log");
+            perror(gorgonad_log_path());
             exit(EXIT_FAILURE);
         } else {
             /* Log rotation is handled internally by log_event() */


### PR DESCRIPTION
# fix(server): дать возможность задать абсолютный путь к gorgonad.log

Нашли при работе над Kubernetes-оператором PostgreSQL HA поверх gorgona-меша, воспроизводится на текущем master.

## Проблема

`gorgonad` открывает лог относительно текущего каталога (`server/gorgonad.c:190`):

```c
log_file = fopen("gorgonad.log", "a");
```

Куда ляжет лог, зависит от того, откуда демон запустили, а настройки нет. Если каталог недоступен на запись, демон не стартует вовсе. В контейнере это обычное дело: рабочий каталог по умолчанию `/`, а процесс запущен не под root.

```
$ su gorgona -c 'cd / && gorgonad'
gorgonad.log: Permission denied
exit=1
```

Тот же относительный путь зашит ещё трижды в `rotate_log()` (`server/gorgona_utils.c:652`), так что и ротация уезжает туда же.

Отдельно сбивает с толку, что readme (строки 285-286) предлагает в юните

```
StandardOutput=append:/var/log/gorgona/gorgonad.log
```

и получается, что рядом живут два разных файла с одним именем: тот, куда пишет systemd, и тот, который демон открывает сам.

## Что в патче

Переменная окружения `gorgonad_LOG_FILE`, симметрично `gorgona_LOG_FILE`, который уже есть на клиенте (`client/alert_listen.c:199`, readme 327). Если не задана, путь остаётся ровно прежним, так что существующие установки не задеты.

Заодно ротация перестала дублировать имя файла и берёт его оттуда же.

Проверка на `debian:bookworm-slim`, тот же запуск из `/` под непривилегированным пользователем:

```
$ su gorgona -c 'cd / && gorgonad_LOG_FILE=/var/log/gorgona/gorgonad.log gorgonad'
Server running on port 7777

$ head -1 /var/log/gorgona/gorgonad.log
2026-08-31 10:08:19 UTC [INFO] [SERVER] Gorgona Server is starting...
```

Без переменной поведение прежнее, лог по-прежнему создаётся в текущем каталоге. Сборка чистая, предупреждений нет.

Если больше нравится ключ в `[server]`-секции конфига, а не переменная окружения, переделаю. Просто env выглядел ближе к тому, как это уже сделано у клиента.
