### PR TITLE
build: подставлять 0.0.0, когда git describe не нашёл тег

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,8 +7,8 @@
 # --- Version Extraction Logic ---
 # Extracts numeric version from tags. Defaults to 0.0.0 if no tags match.
 # ==============================================================================
-CLIENT_VER := $(shell git describe --tags --match "gorgona-v*" --abbrev=0 2>/dev/null | sed 's/gorgona-v//' || echo "0.0.0")
-SERVER_VER := $(shell git describe --tags --match "gorgonad-v*" --abbrev=0 2>/dev/null | sed 's/gorgonad-v//' || echo "0.0.0")
+CLIENT_VER := $(or $(shell git describe --tags --match "gorgona-v*" --abbrev=0 2>/dev/null | sed 's/gorgona-v//'),0.0.0)
+SERVER_VER := $(or $(shell git describe --tags --match "gorgonad-v*" --abbrev=0 2>/dev/null | sed 's/gorgonad-v//'),0.0.0)
 
 # --- Toolchain & Flags ---
 CC      := gcc


### PR DESCRIPTION
# build: подставлять 0.0.0, когда git describe не нашёл тег

Воспроизводится на текущем master.

## Проблема

При сборке из клона без тегов бинарь рапортует пустую версию:

```
Gorgona Client Version 
```

В `Makefile:10` фолбэк на `0.0.0` уже задуман, но не срабатывает:

```make
CLIENT_VER := $(shell git describe --tags --match "gorgona-v*" --abbrev=0 2>/dev/null | sed 's/gorgona-v//' || echo "0.0.0")
```

`git describe` без тега возвращает 128, но код возврата всего конвейера берётся от `sed`, а тот отрабатывает успешно всегда. Поэтому `|| echo "0.0.0"` не выполняется никогда, и на выходе получается `-DVERSION=\"\"`.

Проверка в репозитории без тегов:

```
$ git describe --tags --match "gorgona-v*" --abbrev=0; echo "rc=$?"
rc=128
$ git describe --tags --match "gorgona-v*" --abbrev=0 2>/dev/null | sed 's/gorgona-v//'; echo "rc=$?"
rc=0
```

Чаще всего это вылезает при `git clone --depth 1`, обычное дело в Docker-сборке: теги туда не приезжают.

## Что в патче

`$(or ...)` смотрит на значение, а не на код возврата:

```make
CLIENT_VER := $(or $(shell git describe --tags --match "gorgona-v*" --abbrev=0 2>/dev/null | sed 's/gorgona-v//'),0.0.0)
```

Проверил в обе стороны, собрав на `debian:bookworm-slim`:

```
### без тегов
Gorgona Client Version 0.0.0
Gorgona Server Version 0.0.0

### с тегами gorgona-v3.3.2 / gorgonad-v4.4.4
Gorgona Client Version 3.3.2
Gorgona Server Version 4.4.4
```

До патча первый случай давал `Gorgona Client Version` без номера вообще.

Нашли при сборке образа для Kubernetes-оператора поверх gorgona-меша, где клон делается shallow.
