### PR TITLE
feat(gfm): node_address, чтобы нода могла представляться полным именем

### DIFF
--- a/plugins/gfm/gfm.conf
+++ b/plugins/gfm/gfm.conf
@@ -6,6 +6,10 @@ admin_pub_hash = zpPVK9fbEqo=
 quorum_total_nodes = 3
 # Уникальное имя инстанса для логов и файлов
 cluster_id = pg_prod1_5432 
+# Имя, под которым нода представляется в меше (LEADER_STATUS, status JSON).
+# По умолчанию берётся hostname. В средах с настоящим DNS (Kubernetes, Consul)
+# короткое имя снаружи не резолвится, тогда сюда прописывают полное:
+# node_address = pg17-1.pg17-hdr.demo.svc
 # Список узлов: IP:PORT (через запятую)
 quorum_nodes = 192.168.1.170:5432, 192.168.1.171:5432, 192.168.1.172:7777
 

--- a/plugins/gfm/gfm.py
+++ b/plugins/gfm/gfm.py
@@ -97,7 +97,12 @@ class GFM:
 
         # Секция [cluster]
         self.my_pub_hash = conf.get("cluster", "my_pub_hash")
-        self.node_name = os.uname()[1]
+        # Короткое имя нужно отдельно: под ним нода известна самой себе (/etc/hosts, sudo).
+        self.local_hostname = os.uname()[1]
+        # Имя, под которым нода представляется в меше и в status JSON. В Kubernetes
+        # и других средах с настоящим DNS короткое имя снаружи не резолвится,
+        # поэтому его можно переопределить полным (pg17-1.pg17-hdr.demo.svc).
+        self.node_name = conf.get("cluster", "node_address", fallback="").strip() or self.local_hostname
         self.quorum_total_nodes = conf.getint("cluster", "quorum_total_nodes")
         # Уникальный ID кластера (например, pg_prod_5432) для изоляции логов и статусов
         self.cluster_id = conf.get("cluster", "cluster_id", fallback="default")
@@ -232,10 +237,10 @@ class GFM:
         try:
             with open("/etc/hosts", "r") as f:
                 content = f.read()
-            if self.node_name not in content:
+            if self.local_hostname not in content:
                 self.log("Optimizing local hostname resolution in /etc/hosts...")
                 with open("/etc/hosts", "a") as f:
-                    f.write("\n127.0.0.1 " + self.node_name + "\n")
+                    f.write("\n127.0.0.1 " + self.local_hostname + "\n")
         except Exception as e:
             self.log("Warning: Could not update /etc/hosts: " + str(e))
 

--- a/plugins/gfm/gfm_rebuild.sh
+++ b/plugins/gfm/gfm_rebuild.sh
@@ -47,8 +47,18 @@ LOG_FILE="/var/log/gorgona/rebuild_${CLUSTER_ID}.log"
 
 USER="repuser"
 export PGPASSFILE="/var/lib/postgresql/.pgpass"
-MY_NAME=$(hostname)
-SLOT_NAME="replica_slot_$(echo ${MY_NAME} | tr '-' '_')_${PG_INST}"
+MY_NAME=$(get_val "cluster" "node_address")
+[ -z "$MY_NAME" ] && MY_NAME=$(hostname)
+
+# В именах слотов PostgreSQL допускает только буквы, цифры и подчёркивания,
+# так что точки FQDN и дефисы заменяем. Длина идентификатора ограничена 63
+# символами: если не влезли, оставляем читаемое начало и дописываем хеш от
+# полного имени, иначе две ноды с похожими FQDN получили бы один слот.
+SLOT_NAME="replica_slot_$(echo ${MY_NAME} | tr '.-' '__')_${PG_INST}"
+if [ ${#SLOT_NAME} -gt 63 ]; then
+    SLOT_SUFFIX=$(printf '%s' "$SLOT_NAME" | md5sum | cut -c1-8)
+    SLOT_NAME="$(printf '%s' "$SLOT_NAME" | cut -c1-54)_${SLOT_SUFFIX}"
+fi
 PUB_KEY_ARG="${MY_PUB_HASH}.pub"
 
 log_msg() {

--- a/plugins/gfm/readme.md
+++ b/plugins/gfm/readme.md
@@ -32,6 +32,11 @@ admin_pub_hash = zpPVK9fbEqo=
 quorum_total_nodes = 3
 # Unique cluster identifier used for log isolation and status file naming
 cluster_id = pg_prod_5432 
+# Name this node announces to the mesh (LEADER_STATUS, status JSON).
+# Defaults to the system hostname. In environments with real DNS (Kubernetes,
+# Consul) the short hostname does not resolve from other hosts, so set the
+# fully qualified name here:
+# node_address = pg17-1.pg17-hdr.demo.svc
 # List of cluster members in IP:PORT format (comma-separated)
 # If PORT does not match the PostgreSQL port, the node is treated as a WITNESS.
 quorum_nodes = 192.168.1.170:5432, 192.168.1.171:5432, 192.168.1.172:7777
@@ -211,7 +216,8 @@ Since GFM manages the failover orchestration, you must ensure PostgreSQL is manu
 ### Architecture Logic
 
 - **Smart Rebuild:** The `gfm_rebuild.sh` script automatically attempts `pg_rewind` first (to save bandwidth by rolling back diverged timelines) or falls back to `pg_basebackup` if the local database is empty or corrupted.
-- **Conflict Resolution:** If two nodes claim leadership, the one with the higher LSN wins. If LSNs are equal, the node with the lower alphabetical hostname wins. The "loser" is automatically fenced (stopped) and rebuilt as a standby.
+- **Conflict Resolution:** If two nodes claim leadership, the one with the higher LSN wins. If LSNs are equal, the node with the lower alphabetical name wins. The "loser" is automatically fenced (stopped) and rebuilt as a standby.
+- **Node Naming:** By default a node is known by its `hostname`, both in the mesh and in the replication slot name. Setting `node_address` replaces it with a fully qualified name, which is what makes the cluster work where short names do not resolve. Slot names follow: dots and dashes become underscores, since PostgreSQL only allows letters, digits and underscores there, and a name longer than the 63 character limit keeps a readable prefix plus a hash of the full name.
 - **Decentralized Signaling:** All status updates (`LEADER_STATUS`) and election requests (`CANDIDATE`) are encrypted and broadcasted via the Gorgona P2P Mesh.
 
 ---


### PR DESCRIPTION
# feat(gfm): node_address, чтобы нода могла представляться полным именем

Патч к #11, по твоему выбору: нода публикует в меш полное имя вместо `hostname`.

## Что сделано

`node_address` в секции `[cluster]` переопределяет имя, под которым нода известна в `LEADER_STATUS` и в status JSON. Если ключ не задан, берётся `hostname`, как и раньше, так что на существующих установках ничего не меняется.

Имя ноды читается ровно в одном месте (`gfm.py`, бывшая строка 100), поэтому правка там одна, а все двенадцать мест, где `node_name` используется дальше, подхватывают её сами. Сравнение при равных LSN тоже начинает сравнивать полные имена, ты сказал, что это не смущает.

## Имя слота

Здесь пришлось сделать два ограничения, про которые ты и предупреждал.

Точки FQDN недопустимы в именах слотов, так что они переводятся в подчёркивания вместе с дефисами: `tr '.-' '__'`.

Длина ограничена 63 символами. Обычные k8s-имена помещаются, но с запасом всего в несколько символов, и длинный namespace его съедает:

```
bare metal          replica_slot_gorgonad1_main                                 27
k8s короткое        replica_slot_pg17_1_main                                    24
k8s FQDN            replica_slot_pg17_1_pg17_hdr_demo_svc_main                  42
k8s полный FQDN     replica_slot_pg17_1_pg17_hdr_demo_svc_cluster_local_main    56
длинный namespace   ...до обрезки было бы                                       96
```

Просто обрезать хвост нельзя: имена подов в кластере часто различаются как раз ближе к концу, и две ноды получили бы один слот, а это тихая поломка репликации. Поэтому за пределом 63 символов остаётся читаемое начало и дописывается хеш от полного имени:

```
replica_slot_postgres_cluster_0_postgres_cluster_hdr_p_af46fa64   63
replica_slot_postgres_cluster_1_postgres_cluster_hdr_p_7d532e55   63
```

Проверил и случай, когда имена различаются в самом последнем символе: хеши разные, слоты не совпадают.

## Что осталось на коротком имени

Запись в `/etc/hosts` (`fix_etc_hosts`) продолжает использовать `hostname`. Она нужна для быстрого локального резолва под sudo, и прописывать туда FQDN с адресом 127.0.0.1 было бы неверно: снаружи это же имя должно вести на реальный адрес ноды.

## Проверка на живом PostgreSQL

Поднял два кластера, промоутил второй, развёл первый по timeline и запустил на нём патченный `gfm_rebuild.sh` с `node_address = pg17-0.pg17-hdr.demo.svc.cluster.local`.

```
[pg_test] Data exists. Attempting pg_rewind...
[pg_test] SUCCESS: pg_rewind completed.
[pg_test] Writing recovery configuration for master 127.0.0.1...
[pg_test] Ensuring replication slot replica_slot_pg17_0_pg17_hdr_demo_svc_cluster_local_main on 127.0.0.1...
[pg_test] --- RECOVERY FINISHED SUCCESSFULLY ---
```

Слот реально создан, точки переведены, длина в пределах лимита:

```
replica_slot_pg17_0_pg17_hdr_demo_svc_cluster_local_main | physical | len=56
```

Recovery-конфиг на перестроенной ноде:

```
primary_conninfo = 'host=127.0.0.1 port=5442 user=repuser application_name=pg17-0.pg17-hdr.demo.svc.cluster.local'
primary_slot_name = 'replica_slot_pg17_0_pg17_hdr_demo_svc_cluster_local_main'
```

Репликация поднялась, и мастер видит реплику уже под полным именем:

```
на мастере:  pg17-0.pg17-hdr.demo.svc.cluster.local | streaming | async
на реплике:  streaming | порт источника 5442 | слот replica_slot_pg17_0_..._main
слот:        active=true
```

Запись, сделанная на мастере, доехала до реплики, `received_tli` стал 2.

## Регрессия и граничные случаи

Тот же скрипт с конфигом без `node_address`, как на обычной установке:

```
MY_NAME   = melancholic-theory   (совпадает с hostname)
SLOT_NAME = replica_slot_melancholic_theory_main
```

То есть прежнее поведение сохраняется полностью.

Отдельно прогнал чтение конфига на четырёх вариантах: ключа нет, ключ задан, задан пустым, задан пробелами. Последние два стоили отдельной строчки кода: `configparser` в этом случае возвращает пустую строку, а не фолбэк, и нода уехала бы в меш с пустым именем.

Ветку с обрезкой длинного имени проверил на FQDN с длинным namespace: получается 63 символа ровно, и у двух нод, различающихся только ближе к концу имени, слоты остаются разными.

## Чего я не проверял

Стенд был на PostgreSQL 18 на macOS, а не на Debian с systemd, так что `sudo`, `systemctl`, `flock` и Debian-пути подменялись заглушками. На саму логику имён это не влияет, но полный путь через systemd я не проходил.

`gfm.py` в работающем виде тоже не гонял, у нас в операторе его роль выполняет свой контроллер. Логику чтения конфига и подстановки имени проверил отдельно, но живого демона с выборами лидера под этим патчем не было. Если у тебя есть стенд, где это быстро прогнать, лучше проверить.
