### PR TITLE
test(docker): стенд для меша, где ноды знают друг друга только по имени

### DIFF
--- a/test/docker/Dockerfile
+++ b/test/docker/Dockerfile
@@ -1,0 +1,19 @@
+# Mesh test node: builds gorgonad from the working tree, so the image always
+# carries the code you are about to test. Build context is the repository root:
+#   docker compose -f test/docker/docker-compose.yml up -d --build
+FROM debian:bookworm-slim AS build
+RUN apt-get update -qq \
+    && apt-get install -y -qq --no-install-recommends gcc libc6-dev make libssl-dev > /dev/null
+WORKDIR /src
+COPY Makefile ./
+COPY common/ ./common/
+COPY server/ ./server/
+COPY client/ ./client/
+RUN make > /dev/null
+
+FROM debian:bookworm-slim
+RUN apt-get update -qq \
+    && apt-get install -y -qq --no-install-recommends libssl3 ca-certificates > /dev/null
+COPY --from=build /src/gorgonad /src/gorgona /usr/local/bin/
+RUN mkdir -p /etc/gorgona /var/lib/gorgona /var/log/gorgona
+WORKDIR /var/log/gorgona

--- a/test/docker/check.sh
+++ b/test/docker/check.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# Prints the mesh topology each node sees. With three nodes and no duplicates
+# every node reports "Known nodes: 2", each entry carrying a resolved address.
+PSK=$(sed -n 's/^sync_psk *= *//p' "$(dirname "$0")/node-a.conf" | awk '{print $1}')
+COMPOSE="docker compose -f $(dirname "$0")/docker-compose.yml"
+
+for node in node-a node-b node-c; do
+    echo "--- $node ---"
+    $COMPOSE exec -T "$node" bash -c \
+        "exec 3<>/dev/tcp/localhost/7777 && echo 'status $PSK' >&3 && timeout 5 cat <&3" \
+        2>/dev/null | sed -n '/L2 Cluster Topology/,/^-----/p'
+done

--- a/test/docker/client.conf
+++ b/test/docker/client.conf
@@ -1,0 +1,4 @@
+[server]
+port = 7777
+ip = 127.0.0.1
+sync_psk = BQQCyN8zo4La2lRSIQ2jLp5imEa0JzdXp2PKogP3

--- a/test/docker/docker-compose.yml
+++ b/test/docker/docker-compose.yml
@@ -1,0 +1,25 @@
+# Three nodes that know each other only by name, never by address. Docker's
+# embedded DNS stands in for the Kubernetes headless service: every container
+# is reachable as its service name, and its address changes on recreation.
+services:
+  node-a:
+    build: { context: ../.., dockerfile: test/docker/Dockerfile }
+    hostname: node-a
+    command: ["gorgonad", "-v"]
+    volumes:
+      - ./node-a.conf:/etc/gorgona/gorgonad.conf:ro
+      - ./client.conf:/etc/gorgona/gorgona.conf:ro
+  node-b:
+    build: { context: ../.., dockerfile: test/docker/Dockerfile }
+    hostname: node-b
+    command: ["gorgonad", "-v"]
+    volumes:
+      - ./node-b.conf:/etc/gorgona/gorgonad.conf:ro
+      - ./client.conf:/etc/gorgona/gorgona.conf:ro
+  node-c:
+    build: { context: ../.., dockerfile: test/docker/Dockerfile }
+    hostname: node-c
+    command: ["gorgonad", "-v"]
+    volumes:
+      - ./node-c.conf:/etc/gorgona/gorgonad.conf:ro
+      - ./client.conf:/etc/gorgona/gorgona.conf:ro

--- a/test/docker/node-a.conf
+++ b/test/docker/node-a.conf
@@ -1,0 +1,16 @@
+[server]
+port = 7777
+max_alerts = 1000
+max_alert_ttl = 7776000
+max_clients = 100
+max_log_size = 10
+log_level = debug
+max_message_size = 5
+use_disk_db = false
+vacuum_threshold_percent = 50
+
+[replication]
+sync_psk = BQQCyN8zo4La2lRSIQ2jLp5imEa0JzdXp2PKogP3
+sync_interval = 10
+peer = node-b:7777
+peer = node-c:7777

--- a/test/docker/node-b.conf
+++ b/test/docker/node-b.conf
@@ -1,0 +1,16 @@
+[server]
+port = 7777
+max_alerts = 1000
+max_alert_ttl = 7776000
+max_clients = 100
+max_log_size = 10
+log_level = debug
+max_message_size = 5
+use_disk_db = false
+vacuum_threshold_percent = 50
+
+[replication]
+sync_psk = BQQCyN8zo4La2lRSIQ2jLp5imEa0JzdXp2PKogP3
+sync_interval = 10
+peer = node-a:7777
+peer = node-c:7777

--- a/test/docker/node-c.conf
+++ b/test/docker/node-c.conf
@@ -1,0 +1,16 @@
+[server]
+port = 7777
+max_alerts = 1000
+max_alert_ttl = 7776000
+max_clients = 100
+max_log_size = 10
+log_level = debug
+max_message_size = 5
+use_disk_db = false
+vacuum_threshold_percent = 50
+
+[replication]
+sync_psk = BQQCyN8zo4La2lRSIQ2jLp5imEa0JzdXp2PKogP3
+sync_interval = 10
+peer = node-a:7777
+peer = node-b:7777

--- a/test/docker/readme.md
+++ b/test/docker/readme.md
@@ -1,0 +1,74 @@
+# Mesh test bed: nodes that know each other only by name
+
+Three gorgonad nodes in one Docker network, where every `peer` entry in the
+config is a DNS name and no address is written anywhere. Docker's embedded DNS
+stands in for a Kubernetes headless service: a container answers to its service
+name, and its address changes whenever it is recreated.
+
+The bed was written while testing FQDN support (#9) and reproduces the two
+failure modes that came up there: a node listing itself as a neighbour, and one
+node appearing twice, once by name from the config and once by address from PEX.
+
+## Run
+
+```bash
+docker compose -f test/docker/docker-compose.yml up -d --build
+./test/docker/check.sh
+```
+
+The image is built from the working tree, so it always carries the code you are
+testing.
+
+## What a healthy mesh looks like
+
+Give the nodes a few sync cycles, then every node should report exactly two
+neighbours, each with a resolved address next to the name:
+
+```
+--- node-a ---
+--- L2 Cluster Topology (Known nodes: 2) ---
+  [node-b (172.31.0.3) :7777 ] SEED [UP]
+  [node-c (172.31.0.4) :7777 ] SEED [UP]
+```
+
+Signs of trouble:
+
+- `Known nodes` higher than the number of neighbours: the same node is held
+  twice, usually once by name and once by address.
+- A node listing its own name.
+- An entry with no address in brackets that stays `DEAD` while the node is up:
+  the name was never resolved, so it never merged with the address entry.
+
+## Cold start
+
+The harder case is a node that starts before its neighbours exist, when DNS
+cannot resolve them yet. Start one node alone, let it sit, then bring up the
+rest:
+
+```bash
+docker compose -f test/docker/docker-compose.yml up -d --build node-a
+sleep 15
+docker compose -f test/docker/docker-compose.yml up -d node-b node-c
+```
+
+Entries begin without addresses and should pick them up on a later cycle.
+
+## Message delivery
+
+```bash
+C="docker compose -f test/docker/docker-compose.yml"
+$C exec node-a gorgona genkeys
+KEY=$($C exec -T node-a sh -c 'ls /etc/gorgona/*.pub | head -1 | xargs basename | sed s/.pub//')
+$C exec -T node-a sh -c "cat /etc/gorgona/$KEY.key" > /tmp/k.key
+$C exec -T node-c sh -c "cat > /etc/gorgona/$KEY.key" < /tmp/k.key
+$C exec node-a sh -c "gorgona send \"\$(date -u '+%Y-%m-%d %H:%M:%S')\" \"\$(date -u -d '+1 day' '+%Y-%m-%d %H:%M:%S')\" 'hello over dns' '$KEY.pub'"
+$C exec node-c sh -c "timeout 8 gorgona listen last 1 '$KEY'"
+```
+
+An alert sent from one node should come back on another.
+
+## Cleanup
+
+```bash
+docker compose -f test/docker/docker-compose.yml down
+```


### PR DESCRIPTION
# test(docker): стенд для меша, где ноды знают друг друга только по имени

Обещал в #9 прислать стенд, на котором гонял проверки FQDN. Кладу в `test/docker`, как ты предложил.

## Что это

Три ноды в одной docker-сети, у каждой в конфиге соседи заданы именами, адрес не написан нигде. Встроенный DNS докера тут работает как headless-сервис в Kubernetes: контейнер отвечает на своё имя, а адрес у него меняется при каждом пересоздании.

Стенд писался по ходу issue и воспроизводит оба случая, которые там всплывали: нода видит саму себя среди соседей, и одна нода держится дважды, отдельно по имени из конфига и отдельно по адресу из PEX.

```bash
docker compose -f test/docker/docker-compose.yml up -d --build
./test/docker/check.sh
```

Образ собирается из рабочего дерева, так что в нём всегда тот код, который проверяешь.

## Что показывает

`check.sh` печатает таблицу топологии с каждой ноды. На здоровом меше из трёх нод каждая видит ровно две записи, у каждой рядом с именем стоит адрес:

```
--- node-a ---
--- L2 Cluster Topology (Known nodes: 2) ---
  [node-c (172.31.0.4) :7777 ] SEED [UP]
  [node-b (172.31.0.3) :7777 ] SEED [UP]
```

Регрессия видна сразу: число соседей больше ожидаемого, нода в собственном списке, или запись без адреса, застрявшая в DEAD при живом соседе.

В readme рядом описан отдельно холодный старт, когда нода поднимается раньше соседей и DNS их ещё не резолвит, и проверка доставки сообщения между нодами.

## Прогон на текущем master

```
--- node-a ---  Known nodes: 2   обе записи с адресом, UP
--- node-b ---  Known nodes: 2   обе записи с адресом, UP
--- node-c ---  Known nodes: 2   обе записи с адресом, UP
```

Алерт, отправленный с node-a, читается на node-c:

```
Server Result: Alert ID: 216493302263808 added successfully
Decrypted Content:
hello over dns
```

Команды из readme прогнал ровно в том виде, в каком они там записаны.

## Про PSK

В конфигах лежит тот же тестовый `sync_psk`, что и в примерах в репозитории. Если для тестового окружения хочется отдельный ключ, скажи, поменяю.
